### PR TITLE
fix(training): coherent road long-run distance/duration + taper note

### DIFF
--- a/specs/mon-plan-marathon.md
+++ b/specs/mon-plan-marathon.md
@@ -97,7 +97,7 @@ _Progressive build: 12.0% per week_
 
 ### Semaine 6 · development
 
-Volume cible 21.10 km · TSS 156.60 · 5 séances
+Volume cible 11.90 km · TSS 156.80 · 5 séances
 
 _Progressive build: 12.0% per week_
 
@@ -106,21 +106,21 @@ _Progressive build: 12.0% per week_
 | Monday | RMU | Renforcement Musculaire | 21min | — | — | 2 | 15.80 |
 | Tuesday | TMP | Tempo · Steady Z3 (148-161 bpm) | 24min | — | 4:42 /km | 3 | 27.80 |
 | Thursday | EF | Endurance Fondamentale | 28min | — | 6:05–5:45 /km | 2 | 23.40 |
-| Saturday | SL | Sortie Longue | 1h12 | 21.1 km | 6:05–5:45 /km | 2 | 66.10 |
+| Saturday | SL | Sortie Longue | 1h12 | 11.9 km | 6:05–5:45 /km | 2 | 66.40 |
 | Sunday | EF | Endurance Fondamentale | 28min | — | 6:05–5:45 /km | 2 | 23.40 |
 
 ### Semaine 7 · development
 
-Volume cible 21.10 km · TSS 180.10 · 5 séances
+Volume cible 13.60 km · TSS 179.90 · 5 séances
 
 _Progressive build: 12.0% per week_
 
 | Jour | Type | Séance | Durée | Distance | Allure | FC | TSS |
 |---|---|---|---|---|---|---|---|
 | Monday | RMU | Renforcement Musculaire | 24min | — | — | 2 | 18.20 |
-| Tuesday | TMP | Tempo · Steady Z3 (148-161 bpm) | 27min | — | 4:42 /km | 3 | 32.00 |
+| Tuesday | TMP | Tempo · Steady Z3 (148-161 bpm) | 27min | — | 4:42 /km | 3 | 32.10 |
 | Thursday | EF | Endurance Fondamentale | 32min | — | 6:05–5:45 /km | 2 | 26.90 |
-| Saturday | SL | Sortie Longue | 1h23 | 21.1 km | 6:05–5:45 /km | 2 | 76.00 |
+| Saturday | SL | Sortie Longue | 1h23 | 13.6 km | 6:05–5:45 /km | 2 | 75.80 |
 | Sunday | EF | Endurance Fondamentale | 32min | — | 6:05–5:45 /km | 2 | 26.90 |
 
 ### Semaine 8 · development — récup
@@ -137,7 +137,7 @@ _Recovery week: 40% reduction_
 
 ### Semaine 9 · development
 
-Volume cible 21.10 km · TSS 207.10 · 5 séances
+Volume cible 15.70 km · TSS 207.00 · 5 séances
 
 _Progressive build: 12.0% per week_
 
@@ -146,35 +146,35 @@ _Progressive build: 12.0% per week_
 | Monday | RMU | Renforcement Musculaire | 28min | — | — | 2 | 20.90 |
 | Tuesday | TMP | Tempo · Steady Z3 (148-161 bpm) | 32min | — | 4:42 /km | 3 | 36.80 |
 | Thursday | EF | Endurance Fondamentale | 37min | — | 6:05–5:45 /km | 2 | 30.90 |
-| Saturday | SL | Sortie Longue | 1h35 | 21.1 km | 6:05–5:45 /km | 2 | 87.40 |
+| Saturday | SL | Sortie Longue | 1h36 | 15.7 km | 6:05–5:45 /km | 2 | 87.50 |
 | Sunday | EF | Endurance Fondamentale | 37min | — | 6:05–5:45 /km | 2 | 30.90 |
 
 ### Semaine 10 · development
 
-Volume cible 21.10 km · TSS 238.20 · 5 séances
+Volume cible 18.00 km · TSS 237.90 · 5 séances
 
 _Progressive build: 12.0% per week_
 
 | Jour | Type | Séance | Durée | Distance | Allure | FC | TSS |
 |---|---|---|---|---|---|---|---|
 | Monday | RMU | Renforcement Musculaire | 32min | — | — | 2 | 24.00 |
-| Tuesday | TMP | Tempo · Steady Z3 (148-161 bpm) | 36min | — | 4:42 /km | 3 | 42.40 |
+| Tuesday | TMP | Tempo · Steady Z3 (148-161 bpm) | 36min | — | 4:42 /km | 3 | 42.30 |
 | Thursday | EF | Endurance Fondamentale | 43min | — | 6:05–5:45 /km | 2 | 35.60 |
-| Saturday | SL | Sortie Longue | 1h50 | 21.1 km | 6:05–5:45 /km | 2 | 100.50 |
+| Saturday | SL | Sortie Longue | 1h50 | 18.0 km | 6:05–5:45 /km | 2 | 100.40 |
 | Sunday | EF | Endurance Fondamentale | 43min | — | 6:05–5:45 /km | 2 | 35.60 |
 
 ### Semaine 11 · specific
 
-Volume cible 29.50 km · TSS 273.90 · 5 séances
+Volume cible 25.70 km · TSS 273.20 · 5 séances
 
 _Progressive build: 12.0% per week_
 
 | Jour | Type | Séance | Durée | Distance | Allure | FC | TSS |
 |---|---|---|---|---|---|---|---|
 | Monday | RMU | Renforcement Musculaire | 33min | — | — | 2 | 24.50 |
-| Tuesday | TMP | Tempo · Steady Z3 (148-161 bpm) | 37min | — | 4:42 /km | 3 | 43.30 |
+| Tuesday | TMP | Tempo · Steady Z3 (148-161 bpm) | 37min | — | 4:42 /km | 3 | 43.20 |
 | Thursday | EF | Endurance Fondamentale | 44min | — | 6:05–5:45 /km | 2 | 36.30 |
-| Saturday | SL | Sortie Longue · 11.8 km à allure marathon (4:59 /km) | 2h25 | 29.5 km | 6:05–5:45 /km → 4:59 /km | 2 | 133.30 |
+| Saturday | SL | Sortie Longue · 10.3 km à allure marathon (4:59 /km) | 2h25 | 25.7 km | 6:05–5:45 /km → 4:59 /km | 2 | 132.90 |
 | Sunday | EF | Endurance Fondamentale | 44min | — | 6:05–5:45 /km | 2 | 36.30 |
 
 ### Semaine 12 · specific
@@ -221,7 +221,7 @@ _Progressive build: 12.0% per week_
 
 Volume cible 16.90 km · TSS 250.10 · 5 séances
 
-_Progressive build: 12.0% per week_
+_Taper: reduced volume, intensity kept_
 
 | Jour | Type | Séance | Durée | Distance | Allure | FC | TSS |
 |---|---|---|---|---|---|---|---|
@@ -235,7 +235,7 @@ _Progressive build: 12.0% per week_
 
 Volume cible 16.90 km · TSS 250.10 · 5 séances
 
-_Progressive build: 12.0% per week_
+_Taper: reduced volume, intensity kept_
 
 | Jour | Type | Séance | Durée | Distance | Allure | FC | TSS |
 |---|---|---|---|---|---|---|---|

--- a/src/training/long_run.py
+++ b/src/training/long_run.py
@@ -183,6 +183,8 @@ def _build_road_long_run(
     elif phase == PlanPhase.taper:
         # Cut volume, keep intensity: retain a short marathon-pace block.
         variant = "taper_quality"
+        # The build note is meaningless in the taper (volume goes down, not up).
+        note = "Taper: reduced volume, intensity kept"
         mp_block_km = round(
             min(_ROAD_TAPER_MP_BLOCK_MAX_KM, target_km * _ROAD_TAPER_MP_BLOCK_FRACTION),
             1,
@@ -222,6 +224,50 @@ def _build_road_long_run(
         "easy_pace_sec": ef_sec,
         "marathon_pace_sec": mpr_sec,
     }
+
+
+def scale_long_run_spec(spec: dict, scale: float) -> dict:
+    """Return a copy of a long-run spec with its volume scaled by ``scale``.
+
+    Distance and duration shrink together so the rendered pace stays correct.
+    This backs the plan generator's weekly TSS-progression guard, which used to
+    trim only the duration and leave the distance (and thus the implied pace)
+    incoherent — a 21 km run rendered as 1h12 (3:24/km, impossible). Per-km pace
+    fields and the remaining metadata are preserved.
+
+    Args:
+        spec: A ``calculate_long_run`` output dict.
+        scale: Multiplier; values >= 1.0 return the spec unchanged.
+
+    Returns:
+        A new spec dict with ``target_km`` and ``target_duration_seconds`` scaled
+        (plus ``easy_km`` / ``marathon_pace_block_km`` for road runs). Durations
+        are recomputed from the scaled distances and the preserved paces so the
+        blocks the week builder derives stay self-consistent.
+    """
+    if scale >= 1.0:
+        return spec
+
+    scaled = dict(spec)
+    scaled["target_km"] = round(spec["target_km"] * scale, 1)
+    for key in ("easy_km", "marathon_pace_block_km"):
+        if spec.get(key):
+            scaled[key] = round(spec[key] * scale, 1)
+
+    # Recompute duration from the scaled distances × preserved paces so
+    # distance ÷ duration keeps yielding the right pace. Trail specs carry no
+    # per-km pace, so scale their duration directly.
+    ef_sec = spec.get("easy_pace_sec")
+    if ef_sec is not None:
+        mpr_sec = spec.get("marathon_pace_sec") or ef_sec
+        scaled["target_duration_seconds"] = int(
+            scaled.get("easy_km", 0) * ef_sec
+            + scaled.get("marathon_pace_block_km", 0) * mpr_sec
+        )
+    else:
+        scaled["target_duration_seconds"] = int(spec["target_duration_seconds"] * scale)
+
+    return scaled
 
 
 def _get_starting_long_run(experience: ExperienceLevel) -> float:

--- a/src/training/plan_generator.py
+++ b/src/training/plan_generator.py
@@ -10,16 +10,17 @@ from .models import (
     ExperienceLevel,
     GeneratePlanRequest,
     RaceObjective,
+    SessionType,
 )
 from . import db_operations as db_ops
 from .fitness_snapshot import build_fitness_snapshot
 from .hr_zones import calculate_hr_zones
 from .load_calculator import calculate_session_tss, validate_weekly_progression
-from .long_run import calculate_long_run
+from .long_run import calculate_long_run, scale_long_run_spec
 from .pace_calculator import compute_paces_from_fitness
 from .periodization import build_periodization
 from .race_classifier import classify_race
-from .week_builder import build_week
+from .week_builder import build_week, create_long_run_session
 
 logger = logging.getLogger(__name__)
 
@@ -215,17 +216,7 @@ async def generate_plan(
                 # Inject personalized HR zones into sessions
                 if hr_zones:
                     for s in sessions:
-                        if s.hr_zone_primary:
-                            zone = next(
-                                (z for z in hr_zones if z.zone == s.hr_zone_primary),
-                                None,
-                            )
-                            if zone:
-                                for block in s.blocks:
-                                    if block.hr_zone == s.hr_zone_primary:
-                                        block.description += (
-                                            f" ({zone.hr_min}-{zone.hr_max} bpm)"
-                                        )
+                        _inject_hr_zones(s, hr_zones)
 
                 # Calculate total TSS for validation
                 week_tss = sum(
@@ -242,15 +233,50 @@ async def generate_plan(
                     is_valid, max_tss = validate_weekly_progression(
                         week_tss, previous_week_tss
                     )
-                    if not is_valid:
-                        # Scale down sessions proportionally
-                        scale = max_tss / week_tss if week_tss > 0 else 1.0
+                    if not is_valid and week_tss > 0:
+                        # Scale the week down to respect the +15% TSS rule. The
+                        # long run is rebuilt from a coherently-scaled spec so its
+                        # distance, duration and pace-blocks stay consistent (a
+                        # bare duration trim left "21 km in 1h12" = 3:24/km). Other
+                        # sessions are template-fixed: scale their duration only.
+                        scale = max_tss / week_tss
+                        long_run_spec = scale_long_run_spec(long_run_spec, scale)
+                        scaled_sessions = []
                         for s in sessions:
-                            if s.target_duration_seconds:
-                                s.target_duration_seconds = int(
-                                    s.target_duration_seconds * scale
+                            if s.session_type == SessionType.SL:
+                                new_sl = create_long_run_session(
+                                    day=s.day_of_week,
+                                    experience=experience,
+                                    phase=week_spec.phase,
+                                    long_run_spec=long_run_spec,
+                                    race_flags=race_flags,
                                 )
-                        week_tss = max_tss
+                                if (
+                                    discipline == "road"
+                                    and new_sl.sport_type == "trail_running"
+                                ):
+                                    new_sl.sport_type = "road_running"
+                                if hr_zones:
+                                    _inject_hr_zones(new_sl, hr_zones)
+                                scaled_sessions.append(new_sl)
+                            else:
+                                if s.target_duration_seconds:
+                                    s.target_duration_seconds = int(
+                                        s.target_duration_seconds * scale
+                                    )
+                                scaled_sessions.append(s)
+                        sessions = scaled_sessions
+
+                        # Recompute from the coherently-scaled sessions rather than
+                        # assuming max_tss (elevation/rounding make it slightly off).
+                        week_tss = sum(
+                            calculate_session_tss(
+                                s.session_type,
+                                s.target_duration_seconds or 0,
+                                s.target_elevation_gain_m or 0,
+                            )
+                            for s in sessions
+                        )
 
                 if not week_spec.is_recovery_week:
                     previous_week_tss = week_tss
@@ -367,6 +393,26 @@ async def generate_plan(
         "experience_level": experience.value,
         "status": "draft",
     }
+
+
+def _inject_hr_zones(session, hr_zones) -> None:
+    """Append the athlete's personalized bpm range to a session's matching blocks.
+
+    Mutates ``session`` in place: every workout block whose ``hr_zone`` equals the
+    session's primary zone gets its description suffixed with ``(min-max bpm)``.
+
+    Args:
+        session: The SessionSpec to annotate.
+        hr_zones: The athlete's computed HR zones.
+    """
+    if not session.hr_zone_primary:
+        return
+    zone = next((z for z in hr_zones if z.zone == session.hr_zone_primary), None)
+    if not zone:
+        return
+    for block in session.blocks:
+        if block.hr_zone == session.hr_zone_primary:
+            block.description += f" ({zone.hr_min}-{zone.hr_max} bpm)"
 
 
 def _resolve_day_preferences(

--- a/src/training/week_builder.py
+++ b/src/training/week_builder.py
@@ -101,7 +101,7 @@ def build_week(
         else:
             long_run_day = _find_weekend_day(available_days_sorted)
         if long_run_day:
-            lr_session = _create_long_run_session(
+            lr_session = create_long_run_session(
                 day=long_run_day,
                 experience=experience,
                 phase=phase,
@@ -409,7 +409,7 @@ def _find_weekend_day(available_days: list[int]) -> int | None:
     return None
 
 
-def _create_long_run_session(
+def create_long_run_session(
     day: int,
     experience: ExperienceLevel,
     phase: PlanPhase,

--- a/tests/test_training/test_adaptive_readiness.py
+++ b/tests/test_training/test_adaptive_readiness.py
@@ -3,7 +3,7 @@
 import math
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 from src.training.adaptive.readiness import (
     SecondaryModifiers,

--- a/tests/test_training/test_db_operations.py
+++ b/tests/test_training/test_db_operations.py
@@ -1,6 +1,5 @@
 """Tests for training plan database operations."""
 
-import json
 from datetime import date
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/test_training/test_long_run.py
+++ b/tests/test_training/test_long_run.py
@@ -1,6 +1,6 @@
 """Tests for long run calculator."""
 import pytest
-from src.training.long_run import calculate_long_run
+from src.training.long_run import calculate_long_run, scale_long_run_spec
 from src.training.models import ExperienceLevel, PlanPhase, RaceObjective
 from src.training.pace_calculator import compute_paces
 
@@ -136,6 +136,52 @@ def test_road_pace_labels_from_pace_set():
     result = _road_lr(week=11, phase=PlanPhase.specific, pace_set=paces)
     assert result["easy_pace"] == paces.zones["EF"].label
     assert result["marathon_pace"] == paces.zones["MPR"].label
+
+
+def _implied_pace_sec(spec: dict) -> float:
+    """Pace in seconds/km implied by a spec's distance and duration."""
+    return spec["target_duration_seconds"] / spec["target_km"]
+
+
+def test_scale_long_run_keeps_distance_and_duration_coherent():
+    """Scaling shrinks distance and duration together: implied pace is preserved."""
+    paces = compute_paces(14.5, objective=RaceObjective.performance)
+    spec = _road_lr(week=11, phase=PlanPhase.specific, pace_set=paces)
+
+    scaled = scale_long_run_spec(spec, 0.6)
+
+    assert scaled["target_km"] == pytest.approx(spec["target_km"] * 0.6, abs=0.1)
+    assert scaled["marathon_pace_block_km"] < spec["marathon_pace_block_km"]
+    # The whole point: pace stays the same after scaling (was the bug — duration
+    # was trimmed while distance stayed, yielding impossible paces).
+    assert _implied_pace_sec(scaled) == pytest.approx(_implied_pace_sec(spec), rel=0.05)
+
+
+def test_scale_long_run_noop_when_scale_ge_one():
+    """A scale >= 1 returns the spec unchanged (no inflation)."""
+    spec = _road_lr(week=6, phase=PlanPhase.development)
+    assert scale_long_run_spec(spec, 1.0) is spec
+    assert scale_long_run_spec(spec, 1.5) is spec
+
+
+def test_scale_long_run_trail_spec_scales_duration():
+    """Trail specs (no per-km pace) still scale distance and duration together."""
+    spec = calculate_long_run(
+        week_number=10, total_weeks=12, phase=PlanPhase.specific,
+        is_recovery_week=False, experience=ExperienceLevel.expert,
+        race_distance_km=100, current_long_run_km=25,
+    )
+    scaled = scale_long_run_spec(spec, 0.5)
+    assert scaled["target_km"] == pytest.approx(spec["target_km"] * 0.5, abs=0.1)
+    assert scaled["target_duration_seconds"] < spec["target_duration_seconds"]
+    assert _implied_pace_sec(scaled) == pytest.approx(_implied_pace_sec(spec), rel=0.05)
+
+
+def test_road_taper_note_is_not_progressive_build():
+    """Taper weeks must not carry the misleading 'progressive build' note."""
+    taper = _road_lr(week=16, phase=PlanPhase.taper)
+    assert "build" not in taper["progression_note"].lower()
+    assert "taper" in taper["progression_note"].lower()
 
 
 def test_trail_unaffected_by_road_changes():

--- a/tests/test_training/test_periodization.py
+++ b/tests/test_training/test_periodization.py
@@ -66,8 +66,6 @@ def test_volume_factor_taper():
 def test_20_weeks_expert():
     weeks = build_periodization(20, ExperienceLevel.expert, RaceCategory.ultra_longue)
     assert len(weeks) == 20
-    # Expert: recovery every 4 weeks
-    phases_with_recovery = [(w.week_number, w.is_recovery_week) for w in weeks]
-    # Should have some recovery weeks but not too many
+    # Expert: recovery every 4 weeks — should have some, but not too many
     recovery_count = sum(1 for w in weeks if w.is_recovery_week)
     assert recovery_count >= 3

--- a/tests/test_training/test_plan_generator.py
+++ b/tests/test_training/test_plan_generator.py
@@ -162,6 +162,60 @@ async def test_generate_plan_road_marathon(mock_pool, mock_profile, mock_road_ra
 
 
 @pytest.mark.asyncio
+async def test_generate_plan_long_runs_have_coherent_pace(
+    mock_pool, mock_profile, mock_road_race
+):
+    """Every long run's distance and duration must imply a plausible pace.
+
+    Regression test for the TSS-progression guard that trimmed only the duration
+    and left the distance untouched — a 21 km run rendered as 1h12 (3:24/km,
+    faster than VO2max pace). An SL is easy running plus at most a marathon-pace
+    finish, so its overall pace can never be faster than marathon pace (~4:59).
+    """
+    request = GeneratePlanRequest(
+        race_target_id=2,
+        plan_name="Brugge 3h30",
+        total_weeks=17,
+        start_date=date(2026, 6, 15),
+    )
+
+    with patch("src.training.plan_generator.build_fitness_snapshot") as mock_fitness, \
+         patch("src.training.plan_generator.db_ops") as mock_db:
+
+        from src.training.models import UserFitnessData
+        mock_fitness.return_value = UserFitnessData(
+            vo2_max=52.0, resting_hr=56, max_hr=188,
+            weight_kg=70.0, vma_kmh=14.5,
+            weekly_volume_km=45.0, weekly_elevation_m=200,
+            recent_long_run_km=18.0,
+        )
+        mock_db.get_athlete_profile = AsyncMock(return_value=mock_profile)
+        mock_db.get_race_target = AsyncMock(return_value=mock_road_race)
+
+        await generate_plan(mock_pool, 67, request)
+
+    conn = mock_pool.acquire.return_value.__aenter__.return_value
+    sl_runs = [
+        call.args
+        for call in conn.fetchrow.call_args_list
+        if call.args
+        and "INSERT INTO planned_workouts" in call.args[0]
+        and call.args[10] == "SL"          # session_type
+        and call.args[6]                    # planned_duration_seconds
+        and call.args[7]                    # planned_distance_meters
+    ]
+    assert sl_runs, "expected long-run inserts"
+    for args in sl_runs:
+        duration_s, distance_m = args[6], args[7]
+        pace_sec_per_km = duration_s / (distance_m / 1000)
+        # No long run faster than ~4:50/km (290 s), and a sane upper bound.
+        assert 290 <= pace_sec_per_km <= 540, (
+            f"incoherent SL pace {pace_sec_per_km:.0f} s/km "
+            f"({distance_m / 1000:.1f} km in {duration_s}s)"
+        )
+
+
+@pytest.mark.asyncio
 async def test_generate_plan_no_profile(mock_pool):
     """Test error when no athlete profile exists."""
     request = GeneratePlanRequest(race_target_id=1, total_weeks=12)


### PR DESCRIPTION
## Contexte
Relecture du plan Brugge (suivi du merge PR #2) → un vrai bug moteur : les sorties longues route affichaient des couples distance/durée incohérents (ex. **S6 : 21,1 km en 1h12 = 3:24/km**, plus rapide que l'allure VO2max).

## Cause racine
Dans `plan_generator`, le garde-fou de progression **+15 % TSS/semaine** rabotait uniquement la *durée* des séances, sans toucher la *distance*. Deux contrôleurs sur la même séance :
- **distance** = cap de phase (fonction en marches : base 12,7 / dev 21,1 / spec 29,5 / taper 16,9 km)
- **durée** = rampe TSS lissée

→ la SL gardait la distance plafonnée mais voyait sa durée coupée → allure impossible. Non détecté par les tests Lot 6 (ils testaient `calculate_long_run` en isolation, pas la cohérence après `build_week` + scaling).

## Correctif
- `scale_long_run_spec()` : réduit **distance + durée ensemble**, allures préservées (durée recalculée depuis km scalés × allure/km).
- `plan_generator` : quand le garde-fou se déclenche, **reconstruit la SL** depuis le spec scalé (blocs, descriptions et `target_volume_km` cohérents) ; les autres séances (durée fixée par template) gardent le scaling de durée.
- `week_builder.create_long_run_session()` exposé en public pour réutilisation.
- Note **taper** corrigée (« Taper: reduced volume, intensity kept » au lieu de « progressive build »).

## Résultat
Les sorties longues **rampent ET sont cohérentes** :

| Sem | Avant | Après |
|---|---|---|
| S6 | 21,1 km / 1h12 (3:24/km ❌) | 11,9 km / 1h12 (6:03/km ✅) |
| S7 | 21,1 km / 1h23 | 13,6 km / 1h23 ✅ |
| S9 | 21,1 km / 1h36 | 15,7 km / 1h36 ✅ |
| S10 | 21,1 km / 1h50 | 18,0 km / 1h50 ✅ |

Pic légitime à 29,5 km (specific), taper cohérent à 16,9 km.

## Tests
- **+5 tests** : cohérence d'allure SL bout-en-bout (`test_generate_plan_long_runs_have_coherent_pace`), `scale_long_run_spec` (road/trail/no-op), note taper.
- **949 tests verts**, lint clean (3 lint pré-existants nettoyés au passage).
- `specs/mon-plan-marathon.md` régénéré (plan réel user_id=70 sur UM880).

## Note infra
La régénération a nécessité l'application de `sql/11_road_marathon.sql` sur la base UM880 (colonne `discipline` manquante) — dérive de schéma à tracker (dette connue).