### PR TITLE
fix(auth): unbreak Garmin connect under the rate limiter

### DIFF
--- a/src/api/routers/auth_garmin.py
+++ b/src/api/routers/auth_garmin.py
@@ -142,23 +142,27 @@ async def _finalize_connect(
 @router.post("/connect", response_model=ConnectResponse)
 @limiter.limit(AUTH_RATE_LIMIT)
 async def connect_garmin(
-    http_request: FastAPIRequest, request: ConnectRequest, db=Depends(get_db)
+    request: FastAPIRequest, body: ConnectRequest, db=Depends(get_db)
 ):
-    """Authenticate with Garmin Connect, store encrypted tokens, link to Better-Auth user."""
+    """Authenticate with Garmin Connect, store encrypted tokens, link to Better-Auth user.
+
+    Note: the starlette ``request`` parameter must be named exactly ``request``
+    so slowapi's ``@limiter.limit`` can find it; the JSON payload is ``body``.
+    """
     token_key = os.environ.get("GARMIN_TOKEN_KEY", "")
     if not token_key:
         raise HTTPException(status_code=500, detail="Token encryption not configured")
 
     # Check if this Better-Auth user already has a linked Garmin account
     existing_user_id = None
-    existing = await db.get_user_by_better_auth_id(request.better_auth_user_id)
+    existing = await db.get_user_by_better_auth_id(body.better_auth_user_id)
     if existing:
         # Link exists — remember user_id so we reuse it after auth
         existing_user_id = existing
 
     # Authenticate with Garmin (MFA-aware)
     try:
-        garmin_client = Garmin(request.email, request.password, return_on_mfa=True)
+        garmin_client = Garmin(body.email, body.password, return_on_mfa=True)
         result = garmin_client.login()
     except GarminConnectAuthenticationError:
         raise HTTPException(status_code=401, detail="Garmin authentication failed")
@@ -172,8 +176,8 @@ async def connect_garmin(
         session_id = str(uuid.uuid4())
         _mfa_sessions[session_id] = {
             "client_state": result[1],
-            "email": request.email,
-            "better_auth_user_id": request.better_auth_user_id,
+            "email": body.email,
+            "better_auth_user_id": body.better_auth_user_id,
             "garmin_client": garmin_client,
             "existing_user_id": existing_user_id,
             "created": time.time(),
@@ -186,8 +190,8 @@ async def connect_garmin(
     # No MFA — finalize
     return await _finalize_connect(
         garmin_client,
-        request.email,
-        request.better_auth_user_id,
+        body.email,
+        body.better_auth_user_id,
         db,
         existing_user_id=existing_user_id,
     )
@@ -196,27 +200,31 @@ async def connect_garmin(
 @router.post("/connect/mfa", response_model=ConnectResponse)
 @limiter.limit(AUTH_RATE_LIMIT)
 async def connect_garmin_mfa(
-    http_request: FastAPIRequest, request: MfaRequest, db=Depends(get_db)
+    request: FastAPIRequest, body: MfaRequest, db=Depends(get_db)
 ):
-    """Complete Garmin Connect login with MFA code."""
+    """Complete Garmin Connect login with MFA code.
+
+    The starlette ``request`` parameter must be named exactly ``request`` so
+    slowapi's ``@limiter.limit`` can find it; the JSON payload is ``body``.
+    """
     token_key = os.environ.get("GARMIN_TOKEN_KEY", "")
     if not token_key:
         raise HTTPException(status_code=500, detail="Token encryption not configured")
 
     _cleanup_expired_mfa()
-    session = _mfa_sessions.pop(request.mfa_session_id, None)
+    session = _mfa_sessions.pop(body.mfa_session_id, None)
     if not session:
         raise HTTPException(
             status_code=400,
             detail="MFA session expired or invalid — please restart connection",
         )
 
-    if session["better_auth_user_id"] != request.better_auth_user_id:
+    if session["better_auth_user_id"] != body.better_auth_user_id:
         raise HTTPException(status_code=403, detail="MFA session does not match user")
 
     try:
         oauth1, oauth2 = garth.sso.resume_login(
-            session["client_state"], request.mfa_code
+            session["client_state"], body.mfa_code
         )
     except Exception:
         logger.exception("MFA verification failed")
@@ -238,7 +246,7 @@ async def connect_garmin_mfa(
     return await _finalize_connect(
         garmin_client,
         session["email"],
-        request.better_auth_user_id,
+        body.better_auth_user_id,
         db,
         existing_user_id=session.get("existing_user_id"),
     )

--- a/tests/test_auth_garmin_router.py
+++ b/tests/test_auth_garmin_router.py
@@ -30,8 +30,9 @@ def setup_env():
     """Set required environment variables before each test and disable rate limiter."""
     os.environ["API_KEY"] = TEST_API_KEY
     os.environ["GARMIN_TOKEN_KEY"] = TokenManager.generate_key()
-    # Disable slowapi rate limiter so the /connect and /connect/mfa decorators
-    # don't crash in tests (they require the 'request' kwarg name from slowapi)
+    # Disable slowapi rate limiter for the bulk of tests so repeated /connect
+    # calls don't hit the 5/15min auth limit. The limiter-enabled path is
+    # covered explicitly by TestConnectRateLimiterIntegration.
     from src.api.rate_limit import limiter
     limiter.enabled = False
     yield
@@ -110,6 +111,65 @@ def _make_mock_garmin(display_name="TrailRunner42"):
 # ---------------------------------------------------------------------------
 # POST /connect — success (no MFA)
 # ---------------------------------------------------------------------------
+
+
+class TestConnectRateLimiterIntegration:
+    """Regression: rate-limited auth endpoints must expose the starlette Request
+    as the parameter named ``request`` so slowapi can inject it.
+
+    The endpoints used to name the Request ``http_request`` and the Pydantic body
+    ``request``; with the limiter enabled (as in prod) slowapi found the body and
+    raised 'parameter `request` must be an instance of starlette.requests.Request'
+    → every Garmin connect attempt 500'd. These tests run with the limiter
+    ENABLED, unlike the rest of the suite.
+    """
+
+    def test_connect_works_with_rate_limiter_enabled(
+        self, client, valid_headers, mock_db
+    ):
+        """/connect must not 500 from slowapi when the limiter is active."""
+        from src.api.rate_limit import limiter
+
+        mock_garmin = _make_mock_garmin("TrailRunner42")
+        limiter.enabled = True
+        try:
+            with patch(
+                "src.api.routers.auth_garmin.Garmin", return_value=mock_garmin
+            ):
+                response = client.post(
+                    "/api/v1/auth/connect",
+                    json={
+                        "email": "trail@runner.com",
+                        "password": "secret",
+                        "better_auth_user_id": TEST_BETTER_AUTH_USER_ID,
+                    },
+                    headers=valid_headers,
+                )
+        finally:
+            limiter.enabled = False
+        assert response.status_code == 200
+        assert response.json()["connected"] is True
+
+    def test_connect_mfa_works_with_rate_limiter_enabled(self, client, valid_headers):
+        """/connect/mfa must reach its handler (400 on bad session), not 500."""
+        from src.api.rate_limit import limiter
+
+        limiter.enabled = True
+        try:
+            response = client.post(
+                "/api/v1/auth/connect/mfa",
+                json={
+                    "mfa_session_id": "does-not-exist",
+                    "mfa_code": "123456",
+                    "better_auth_user_id": TEST_BETTER_AUTH_USER_ID,
+                },
+                headers=valid_headers,
+            )
+        finally:
+            limiter.enabled = False
+        # 400 = handler ran and rejected the unknown session. Before the fix
+        # slowapi 500'd before the handler was reached.
+        assert response.status_code == 400
 
 
 class TestConnectSuccess:


### PR DESCRIPTION
## Symptôme
Toute tentative de connexion Garmin sur hillsrun.com renvoie **502** (500 côté API). Conséquence : impossible de (re)connecter un compte Garmin → tokens figés, sync bloquée.

## Cause racine
Les endpoints rate-limités `/api/v1/auth/connect` et `/api/v1/auth/connect/mfa` nommaient le `starlette.Request` **`http_request`** et le body Pydantic **`request`** :

```python
@limiter.limit(AUTH_RATE_LIMIT)
async def connect_garmin(http_request: FastAPIRequest, request: ConnectRequest, ...):
```

slowapi (`@limiter.limit`) cherche un kwarg nommé exactement **`request`** et vérifie que c'est un `starlette.Request`. Il tombait sur le body Pydantic → 
```
Exception: parameter `request` must be an instance of starlette.requests.Request
```
→ **500 à chaque appel**. Introduit par `c526031` (ajout du rate limiting slowapi).

**Pourquoi le CI ne l'a pas vu :** la fixture de test désactivait le limiter (`limiter.enabled = False`), masquant exactement le chemin cassé en prod.

## Correctif
- Renommer le `Request` en `request` et le body en `body` sur les 2 endpoints (+ MAJ des références `body.email`, `body.mfa_code`, etc.).
- Le `/disconnect` (non rate-limité) est inchangé.

## Tests
- **2 tests de régression** qui tournent avec le **limiter ACTIVÉ** (`connect` → 200, `connect/mfa` → 400 sur session inconnue). Vérifié : les deux **échouent en 500 sur le code pré-fix**, passent après.
- Suite complète : **946 verts**.

## Déploiement
À merger sur `main` → Coolify redéploie le service `api`. Après déploiement : l'utilisateur pourra reconnecter Garmin depuis Réglages, ce qui régénérera des tokens valides et débloquera la sync.