### PR TITLE
fix(auth): migrate Garmin token + MFA flow to garminconnect 0.3.x

### DIFF
--- a/src/api/routers/auth_garmin.py
+++ b/src/api/routers/auth_garmin.py
@@ -11,7 +11,6 @@ from fastapi import APIRouter, Depends, HTTPException, Request as FastAPIRequest
 from pydantic import BaseModel
 
 from garminconnect import Garmin, GarminConnectAuthenticationError
-import garth
 
 from ..auth import get_api_key
 from ..dependencies import get_db
@@ -91,7 +90,9 @@ async def _finalize_connect(
 
     display_name = garmin_client.display_name or garmin_client.full_name
 
-    token_data = garmin_client.garth.dumps()
+    # garminconnect 0.3.x serializes its native DI tokens via the inner client
+    # (.client.dumps()); the Garmin object no longer exposes a .garth attribute.
+    token_data = garmin_client.client.dumps()
     tm = TokenManager(token_key)
     encrypted = tm.encrypt(token_data)
 
@@ -175,7 +176,8 @@ async def connect_garmin(
         _cleanup_expired_mfa()
         session_id = str(uuid.uuid4())
         _mfa_sessions[session_id] = {
-            "client_state": result[1],
+            # The Garmin object holds the in-progress MFA state internally; we
+            # reuse it in /connect/mfa (garminconnect 0.3.x design).
             "email": body.email,
             "better_auth_user_id": body.better_auth_user_id,
             "garmin_client": garmin_client,
@@ -222,26 +224,17 @@ async def connect_garmin_mfa(
     if session["better_auth_user_id"] != body.better_auth_user_id:
         raise HTTPException(status_code=403, detail="MFA session does not match user")
 
+    # garminconnect 0.3.x keeps the in-progress MFA state inside the SAME Garmin
+    # object created at /connect (the client_state arg is ignored). resume_login
+    # completes the SSO with the code and populates display_name/full_name.
+    garmin_client = session["garmin_client"]
     try:
-        oauth1, oauth2 = garth.sso.resume_login(
-            session["client_state"], body.mfa_code
-        )
+        garmin_client.resume_login(None, body.mfa_code)
+    except GarminConnectAuthenticationError:
+        raise HTTPException(status_code=401, detail="MFA verification failed")
     except Exception:
         logger.exception("MFA verification failed")
         raise HTTPException(status_code=401, detail="MFA verification failed")
-
-    garmin_client = session["garmin_client"]
-    # Set the real OAuth tokens (login() with return_on_mfa stored intermediate state)
-    garmin_client.garth.oauth1_token = oauth1
-    garmin_client.garth.oauth2_token = oauth2
-
-    # Load profile after MFA completion
-    try:
-        prof = garmin_client.garth.connectapi("/userprofile-service/usersettings")
-        garmin_client.display_name = prof.get("displayName")
-        garmin_client.full_name = prof.get("fullName") or prof.get("displayName")
-    except Exception:
-        logger.warning("Could not load Garmin profile after MFA")
 
     return await _finalize_connect(
         garmin_client,

--- a/src/garmin_client.py
+++ b/src/garmin_client.py
@@ -6,7 +6,6 @@ from datetime import date
 from typing import Optional, Dict, Any, List
 
 from garminconnect import Garmin, GarminConnectAuthenticationError
-import garth
 
 from .config import GarminConfig
 from .utils.retry import retry_api_call, safe_api_call
@@ -48,48 +47,34 @@ class GarminClient:
         tm = TokenManager(token_key)
         token_data = tm.decrypt(encrypted_tokens)
 
-        garth_client = garth.Client()
-        garth_client.loads(token_data)
-
         instance = cls.__new__(cls)
         instance.config = None
         instance.rate_limit_delay = rate_limit_delay
         instance._last_request_time = 0.0
 
-        instance.client = Garmin()
-        instance.client.garth = garth_client
+        # garminconnect 0.3.x owns its native DI-token client (garth is dropped).
+        # login(tokenstore=<dumped JSON>) loads the tokens, refreshes them when
+        # expiring, and populates the profile (display_name) used in API paths.
+        client = Garmin()
+        client.login(tokenstore=token_data)
+        instance.client = client
 
-        prof = garth_client.profile
-        instance.client.display_name = prof.get("displayName")
-        instance.client.full_name = prof.get("fullName")
-        logger.info(
-            f"Connected to Garmin from DB tokens as {instance.client.display_name}"
-        )
+        logger.info(f"Connected to Garmin from DB tokens as {client.display_name}")
 
         return instance
 
     def get_refreshed_tokens(self) -> str:
-        """Export current garth tokens as JSON string (after potential refresh)."""
-        return self.client.garth.dumps()
+        """Export current Garmin session tokens as a JSON string (post-refresh)."""
+        return self.client.client.dumps()
 
     def connect(self) -> None:
         """Connect to Garmin Connect using stored tokens."""
         try:
             tokens_dir = str(self.config.tokens_dir)
 
-            # Create a garth client and load tokens into it
-            garth_client = garth.Client()
-            garth_client.load(tokens_dir)
-            logger.info(f"Loaded Garmin tokens from {tokens_dir}")
-
-            # Initialize Garmin client and inject our configured garth client
+            # garminconnect 0.3.x restores its own token store from the directory.
             self.client = Garmin()
-            self.client.garth = garth_client
-
-            # Fetch profile to set display_name (required for API URL paths)
-            prof = garth_client.profile
-            self.client.display_name = prof.get("displayName")
-            self.client.full_name = prof.get("fullName")
+            self.client.login(tokenstore=tokens_dir)
             logger.info(
                 f"Successfully connected to Garmin Connect as {self.client.display_name}"
             )

--- a/tests/test_auth_garmin_router.py
+++ b/tests/test_auth_garmin_router.py
@@ -92,19 +92,19 @@ def client(mock_db):
 
 
 def _make_mock_garmin(display_name="TrailRunner42"):
-    """Return a mock Garmin client that looks authenticated."""
+    """Return a mock garminconnect.Garmin (0.3.x) that looks authenticated.
+
+    In 0.3.x the Garmin object owns an inner ``.client`` that serializes the
+    native DI tokens (``.client.dumps()``) and there is no ``.garth`` attribute;
+    MFA is completed via ``.resume_login(client_state, code)``.
+    """
     garmin_client = MagicMock()
     garmin_client.display_name = display_name
     garmin_client.full_name = display_name
-    garmin_client.login = MagicMock(return_value=None)  # non-tuple → no MFA
-    garmin_client.garth = MagicMock()
-    garmin_client.garth.dumps = MagicMock(return_value="fake-token-data")
-    garmin_client.garth.oauth1_token = None
-    garmin_client.garth.oauth2_token = None
-    garmin_client.garth.connectapi = MagicMock(return_value={
-        "displayName": display_name,
-        "fullName": display_name,
-    })
+    garmin_client.login = MagicMock(return_value=(None, None))  # clean → no MFA
+    garmin_client.resume_login = MagicMock(return_value=(None, None))
+    garmin_client.client = MagicMock()
+    garmin_client.client.dumps = MagicMock(return_value='{"di_token":"fake"}')
     return garmin_client
 
 
@@ -414,7 +414,6 @@ class TestConnectMfaEndpoint:
             mock_garmin = _make_mock_garmin()
 
         _mfa_sessions[session_id] = {
-            "client_state": {"state": "pending"},
             "email": "mfa@runner.com",
             "better_auth_user_id": better_auth_user_id,
             "garmin_client": mock_garmin,
@@ -428,22 +427,18 @@ class TestConnectMfaEndpoint:
         mock_garmin = _make_mock_garmin("MfaRunner")
         self._seed_mfa_session(session_id, TEST_BETTER_AUTH_USER_ID, mock_garmin)
 
-        fake_oauth1 = MagicMock()
-        fake_oauth2 = MagicMock()
+        response = client.post(
+            "/api/v1/auth/connect/mfa",
+            json={
+                "mfa_session_id": session_id,
+                "mfa_code": "123456",
+                "better_auth_user_id": TEST_BETTER_AUTH_USER_ID,
+            },
+            headers=valid_headers,
+        )
 
-        with patch("src.api.routers.auth_garmin.garth") as mock_garth:
-            mock_garth.sso.resume_login = MagicMock(return_value=(fake_oauth1, fake_oauth2))
-
-            response = client.post(
-                "/api/v1/auth/connect/mfa",
-                json={
-                    "mfa_session_id": session_id,
-                    "mfa_code": "123456",
-                    "better_auth_user_id": TEST_BETTER_AUTH_USER_ID,
-                },
-                headers=valid_headers,
-            )
-
+        # resume_login completes the in-progress MFA on the same Garmin object.
+        mock_garmin.resume_login.assert_called_once()
         assert response.status_code == 200
         body = response.json()
         assert body["connected"] is True
@@ -484,21 +479,24 @@ class TestConnectMfaEndpoint:
 
     def test_mfa_wrong_code_returns_401(self, client, valid_headers):
         """POST /connect/mfa returns 401 if the MFA code verification fails."""
+        from garminconnect import GarminConnectAuthenticationError
+
         session_id = "test-session-uuid-003"
-        self._seed_mfa_session(session_id, TEST_BETTER_AUTH_USER_ID)
+        mock_garmin = _make_mock_garmin()
+        mock_garmin.resume_login = MagicMock(
+            side_effect=GarminConnectAuthenticationError("wrong code")
+        )
+        self._seed_mfa_session(session_id, TEST_BETTER_AUTH_USER_ID, mock_garmin)
 
-        with patch("src.api.routers.auth_garmin.garth") as mock_garth:
-            mock_garth.sso.resume_login = MagicMock(side_effect=Exception("wrong code"))
-
-            response = client.post(
-                "/api/v1/auth/connect/mfa",
-                json={
-                    "mfa_session_id": session_id,
-                    "mfa_code": "000000",
-                    "better_auth_user_id": TEST_BETTER_AUTH_USER_ID,
-                },
-                headers=valid_headers,
-            )
+        response = client.post(
+            "/api/v1/auth/connect/mfa",
+            json={
+                "mfa_session_id": session_id,
+                "mfa_code": "000000",
+                "better_auth_user_id": TEST_BETTER_AUTH_USER_ID,
+            },
+            headers=valid_headers,
+        )
 
         assert response.status_code == 401
         assert "MFA verification failed" in response.json()["detail"]

--- a/tests/test_garmin_client.py
+++ b/tests/test_garmin_client.py
@@ -4,13 +4,12 @@ import json
 import time
 import pytest
 from datetime import date
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 from garminconnect import GarminConnectAuthenticationError, GarminConnectConnectionError, GarminConnectTooManyRequestsError
 from garth.exc import GarthHTTPError
 from tenacity import RetryError
 
-from src.config import GarminConfig
 from src.garmin_client import GarminClient
 from src.token_manager import TokenManager
 from src.utils.retry import safe_api_call
@@ -71,48 +70,36 @@ class TestGarminClientConnect:
     """Tests for GarminClient.connect()."""
 
     def test_connect_success(self, test_garmin_config):
-        """connect() loads tokens, creates the Garmin client, and sets display_name."""
-        mock_garth_client = MagicMock()
-        mock_garth_client.profile = {
-            "displayName": "testuser",
-            "fullName": "Test User",
-        }
-
-        with patch("src.garmin_client.garth.Client", return_value=mock_garth_client) as mock_garth_cls, \
-             patch("src.garmin_client.Garmin") as mock_garmin_cls:
-
+        """connect() restores the Garmin client via login(tokenstore=<dir>)."""
+        with patch("src.garmin_client.Garmin") as mock_garmin_cls:
             mock_garmin_instance = MagicMock()
             mock_garmin_cls.return_value = mock_garmin_instance
 
             gc = GarminClient(test_garmin_config)
             gc.connect()
 
-            # garth.Client().load() must be called with the tokens directory
-            mock_garth_client.load.assert_called_once_with(str(test_garmin_config.tokens_dir))
-
-            # The inner Garmin instance must be assigned
+            # garminconnect 0.3.x restores its own token store from the directory.
+            mock_garmin_instance.login.assert_called_once_with(
+                tokenstore=str(test_garmin_config.tokens_dir)
+            )
             assert gc.client is mock_garmin_instance
-
-            # display_name and full_name must be set from the profile
-            assert mock_garmin_instance.display_name == "testuser"
-            assert mock_garmin_instance.full_name == "Test User"
 
     def test_connect_missing_tokens_raises_auth_error(self, test_garmin_config):
         """connect() raises GarminConnectAuthenticationError when tokens are absent."""
-        mock_garth_client = MagicMock()
-        mock_garth_client.load.side_effect = FileNotFoundError("no tokens")
-
-        with patch("src.garmin_client.garth.Client", return_value=mock_garth_client):
+        with patch("src.garmin_client.Garmin") as mock_garmin_cls:
+            mock_garmin_cls.return_value.login.side_effect = FileNotFoundError(
+                "no tokens"
+            )
             gc = GarminClient(test_garmin_config)
             with pytest.raises(GarminConnectAuthenticationError):
                 gc.connect()
 
     def test_connect_general_exception_propagates(self, test_garmin_config):
         """connect() re-raises unexpected exceptions unchanged."""
-        mock_garth_client = MagicMock()
-        mock_garth_client.load.side_effect = RuntimeError("unexpected failure")
-
-        with patch("src.garmin_client.garth.Client", return_value=mock_garth_client):
+        with patch("src.garmin_client.Garmin") as mock_garmin_cls:
+            mock_garmin_cls.return_value.login.side_effect = RuntimeError(
+                "unexpected failure"
+            )
             gc = GarminClient(test_garmin_config)
             with pytest.raises(RuntimeError, match="unexpected failure"):
                 gc.connect()
@@ -173,12 +160,7 @@ class TestFromEncryptedTokens:
         tm = TokenManager(token_key)
         encrypted = tm.encrypt(token_data)
 
-        mock_garth_client = MagicMock()
-        mock_garth_client.profile = {"displayName": "dbuser", "fullName": "DB User"}
-
-        with patch("src.garmin_client.garth.Client", return_value=mock_garth_client) as mock_garth_cls, \
-             patch("src.garmin_client.Garmin") as mock_garmin_cls:
-
+        with patch("src.garmin_client.Garmin") as mock_garmin_cls:
             mock_garmin_instance = MagicMock()
             mock_garmin_cls.return_value = mock_garmin_instance
 
@@ -187,11 +169,9 @@ class TestFromEncryptedTokens:
             # Must be a GarminClient
             assert isinstance(instance, GarminClient)
 
-            # garth_client.loads() must have been called with the decrypted JSON
-            mock_garth_client.loads.assert_called_once_with(token_data)
-
-            # display_name set from profile
-            assert mock_garmin_instance.display_name == "dbuser"
+            # garminconnect restores via login(tokenstore=<decrypted JSON>)
+            mock_garmin_instance.login.assert_called_once_with(tokenstore=token_data)
+            assert instance.client is mock_garmin_instance
 
             # rate_limit_delay default
             assert instance.rate_limit_delay == 0.5
@@ -203,13 +183,10 @@ class TestFromEncryptedTokens:
         tm = TokenManager(token_key)
         encrypted = tm.encrypt(token_data)
 
-        mock_garth_client = MagicMock()
-        mock_garth_client.profile = {"displayName": "u", "fullName": "U"}
-
-        with patch("src.garmin_client.garth.Client", return_value=mock_garth_client), \
-             patch("src.garmin_client.Garmin"):
-
-            instance = GarminClient.from_encrypted_tokens(encrypted, token_key, rate_limit_delay=1.5)
+        with patch("src.garmin_client.Garmin"):
+            instance = GarminClient.from_encrypted_tokens(
+                encrypted, token_key, rate_limit_delay=1.5
+            )
             assert instance.rate_limit_delay == 1.5
 
 
@@ -221,22 +198,22 @@ class TestGetRefreshedTokens:
     """Tests for GarminClient.get_refreshed_tokens()."""
 
     def test_returns_string(self, test_garmin_config):
-        """get_refreshed_tokens() returns a string (JSON export from garth)."""
+        """get_refreshed_tokens() returns a string (JSON export from the client)."""
         gc = GarminClient(test_garmin_config)
         gc.client = MagicMock()
-        gc.client.garth.dumps.return_value = '{"access_token": "new_token"}'
+        gc.client.client.dumps.return_value = '{"di_token": "new_token"}'
 
         result = gc.get_refreshed_tokens()
 
         assert isinstance(result, str)
-        gc.client.garth.dumps.assert_called_once()
+        gc.client.client.dumps.assert_called_once()
 
     def test_returns_garth_dumps_output(self, test_garmin_config):
-        """get_refreshed_tokens() returns exactly what garth.dumps() produces."""
+        """get_refreshed_tokens() returns exactly what client.dumps() produces."""
         gc = GarminClient(test_garmin_config)
         gc.client = MagicMock()
         expected = '{"some": "token_data"}'
-        gc.client.garth.dumps.return_value = expected
+        gc.client.client.dumps.return_value = expected
 
         assert gc.get_refreshed_tokens() == expected
 


### PR DESCRIPTION
## Contexte
Après le déploiement UM880, la connexion Garmin échoue (« MFA verification failed ») **et** la sync renvoie « Not authenticated ». Cause commune : le rebuild a tiré **garminconnect 0.3.x**, qui a abandonné `garth` au profit de son **propre client à tokens DI natifs** + un **nouveau format de tokens**.

> *garminconnect 0.3.x : "The old garth-based login no longer works… now authenticates using the mobile SSO flow… Saved tokens are stored in a new format — a fresh login is required after upgrading. No code changes needed, **except when you store/handle tokens in your own project**."*

L'app fait précisément du stockage/handling de tokens custom → cassé partout.

## Bugs corrigés
| Zone | Avant (cassé en 0.3.x) | Après |
|---|---|---|
| **Sync** | `from_encrypted_tokens` injectait les tokens dans `Garmin().garth` (ignoré) → API « Not authenticated » | `Garmin().login(tokenstore=<json>)` charge dans le `.client` natif |
| **MFA** | `login(return_on_mfa=True)` renvoie `('needs_mfa', None)` *par design* (état gardé en interne) ; l'app passait ce `None` à `garth.sso.resume_login` → `NoneType is not subscriptable` | réutilise le **même objet `Garmin`** via `garmin_client.resume_login()` |
| **Dump** | `garmin_client.garth.dumps()` — `Garmin` n'a plus `.garth` | `garmin_client.client.dumps()` |

## Changements
- `garmin_client.py` : `from_encrypted_tokens` + `connect()` restaurent via `Garmin().login(tokenstore=...)` ; `get_refreshed_tokens` via `.client.dumps()` ; import `garth` retiré.
- `auth_garmin.py` : `/connect/mfa` appelle `garmin_client.resume_login()` ; `_finalize_connect` dump via `.client` ; `client_state` (inutile) retiré ; import `garth` retiré.
- Tests : mocks mis au format 0.3.x (`.client.dumps` / `.resume_login`, plus de `.garth`).

## Tests
- **951 verts**, lint clean.
- ⚠️ Les tests valident les *patterns d'appel* (mocks). Le vrai SSO/MFA Garmin + round-trip tokens ne se valide qu'après déploiement.

## Déploiement & validation
1. Merge → **Deploy manuel Coolify** (`hillsrun-prod`, pas de webhook auto).
2. Réglages → reconnecter Garmin (email + mdp + MFA) → doit aboutir.
3. Les nouveaux tokens (format 0.3.x) débloquent la sync.

Dépend de #4 (fix rate-limiter) déjà mergé.