### PR TITLE
feat(training-plan): road discipline + target time in the plan wizard

### DIFF
--- a/web/src/app/(dashboard)/training-plan/new/page.tsx
+++ b/web/src/app/(dashboard)/training-plan/new/page.tsx
@@ -34,6 +34,13 @@ const DAY_LABELS: Record<number, string> = {
   1: "Mon", 2: "Tue", 3: "Wed", 4: "Thu", 5: "Fri", 6: "Sat", 7: "Sun",
 };
 
+/** Parse a "h:mm:ss" or "h:mm" goal time into seconds; null if malformed. */
+function parseHmsToSeconds(value: string): number | null {
+  const m = value.trim().match(/^(\d{1,2}):([0-5]?\d)(?::([0-5]?\d))?$/);
+  if (!m) return null;
+  return Number(m[1]) * 3600 + Number(m[2]) * 60 + Number(m[3] ?? 0);
+}
+
 export default function NewTrainingPlanPage() {
   const router = useRouter();
   const [step, setStep] = useState(0);
@@ -55,7 +62,10 @@ export default function NewTrainingPlanPage() {
     distance_km: 0,
     elevation_gain_m: 0,
     objective: "finish",
+    discipline: "trail",
   });
+  // Goal finish time as "h:mm:ss" (road only); parsed to seconds on submit.
+  const [targetTime, setTargetTime] = useState("");
   const [selectedRaceId, setSelectedRaceId] = useState<number | null>(null);
 
   const [planName, setPlanName] = useState("");
@@ -86,7 +96,12 @@ export default function NewTrainingPlanPage() {
   }
 
   async function handleCreateRace() {
-    const result = await createRace.mutateAsync(raceForm);
+    // Road marathons drive the VMA-based engine; attach the goal time (seconds).
+    const body: RaceTargetCreate =
+      raceForm.discipline === "road"
+        ? { ...raceForm, target_time_seconds: parseHmsToSeconds(targetTime) }
+        : raceForm;
+    const result = await createRace.mutateAsync(body);
     setSelectedRaceId(result.id);
     setStep(2);
   }
@@ -313,14 +328,19 @@ export default function NewTrainingPlanPage() {
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label>Elevation Gain (m)</Label>
-                  <Input
-                    type="number"
-                    value={raceForm.elevation_gain_m || ""}
-                    onChange={(e) =>
-                      setRaceForm({ ...raceForm, elevation_gain_m: Number(e.target.value) })
-                    }
-                  />
+                  <Label>Discipline</Label>
+                  <Select
+                    value={raceForm.discipline}
+                    onValueChange={(v) => setRaceForm({ ...raceForm, discipline: v })}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="trail">Trail</SelectItem>
+                      <SelectItem value="road">Road (marathon)</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
                 <div className="space-y-2">
                   <Label>Objective</Label>
@@ -335,6 +355,32 @@ export default function NewTrainingPlanPage() {
                     </SelectContent>
                   </Select>
                 </div>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                {raceForm.discipline === "road" ? (
+                  <div className="space-y-2">
+                    <Label>Target time (h:mm:ss)</Label>
+                    <Input
+                      value={targetTime}
+                      onChange={(e) => setTargetTime(e.target.value)}
+                      placeholder="3:30:00"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      Drives marathon paces (VMA-based). Leave empty to skip.
+                    </p>
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    <Label>Elevation Gain (m)</Label>
+                    <Input
+                      type="number"
+                      value={raceForm.elevation_gain_m || ""}
+                      onChange={(e) =>
+                        setRaceForm({ ...raceForm, elevation_gain_m: Number(e.target.value) })
+                      }
+                    />
+                  </div>
+                )}
               </div>
               <Button
                 onClick={handleCreateRace}

--- a/web/src/types/garmin.ts
+++ b/web/src/types/garmin.ts
@@ -307,6 +307,8 @@ export interface RaceTarget {
   cutoff_hours: number | null;
   itra_points: number | null;
   objective: string;
+  discipline: string;
+  target_time_seconds: number | null;
   elevation_profile: Record<string, unknown> | null;
   created_at: string | null;
   updated_at: string | null;
@@ -324,6 +326,11 @@ export interface RaceTargetCreate {
   cutoff_hours?: number;
   itra_points?: number;
   objective?: string;
+  // 'trail' (default) | 'road'. Road enables the marathon engine
+  // (VMA-derived paces, marathon-pace finish blocks, 35 km cap).
+  discipline?: string;
+  // Goal finish time in seconds (e.g. 12600 = 3h30); used by the road engine.
+  target_time_seconds?: number | null;
 }
 
 export interface GeneratePlanRequest {


### PR DESCRIPTION
## Pourquoi
L'assistant de création de plan (`/training-plan/new`) ne permettait de régler que l'**objectif** : toute course créée depuis l'app retombait sur `discipline='trail'` sans temps cible → **impossible de générer le plan marathon route** (allures dérivées VMA, blocs allure-marathon en sortie longue, cap 35 km) depuis l'UI. Le backend supportait déjà les deux champs (`discipline`, `target_time_seconds`).

## Changements (frontend uniquement)
- Sélecteur **Discipline** (Trail | Road) ajouté à l'étape « Race ».
- En **Road**, le champ dénivelé est remplacé par **« Target time (h:mm:ss) »** (ex. `3:30:00`), parsé en `target_time_seconds`. En Trail, le champ dénivelé reste.
- `discipline` + `target_time_seconds` câblés dans les types `RaceTargetCreate`/`RaceTarget` et l'appel de création de course.

## Validation
- `pnpm lint` ✅, `pnpm build` ✅ (`/training-plan/new` compile), **285 tests Vitest** ✅.
- Chaîne vérifiée : le formulaire POST le body complet → `db_ops.create_race_target` INSERT `discipline` + `target_time_seconds` → `generate_plan` bascule sur le moteur route.

## Déploiement
Frontend → après merge, **redéployer le service `web`** via Coolify (deploy manuel). Ensuite : `/training-plan/new` → Race → Discipline = Road + Target time `3:30:00` → génère le vrai plan marathon route depuis l'app.