### PR TITLE
style(training): ruff format week_builder.py (unblock main CI)

### DIFF
--- a/src/training/week_builder.py
+++ b/src/training/week_builder.py
@@ -469,12 +469,12 @@ def create_long_run_session(
                 hr_zone=3,
                 description=f"{mp_block_km:g} km à allure marathon"
                 + (f" ({mp_pace})" if mp_pace else "")
-                + (" — terminer plus vite que l'allure marathon" if fast_finish else ""),
+                + (
+                    " — terminer plus vite que l'allure marathon" if fast_finish else ""
+                ),
             ),
         ]
-        description += (
-            f" — dont {mp_block_km:g} km à allure marathon en fin de sortie"
-        )
+        description += f" — dont {mp_block_km:g} km à allure marathon en fin de sortie"
 
     description += f" ({long_run_spec.get('progression_note', '')})"
 


### PR DESCRIPTION
Le fix de câblage de la sortie longue allure-marathon (`ff896f7`) a laissé `week_builder.py` non formaté, ce qui rend rouge l'étape CI `ruff format --check` sur `main`.

Formatting-only, aucun changement de logique. `ruff format --check src/` → 59/59 OK.