### PR TITLE
fix(training): decode JSONB profile fields read back as strings

### DIFF
--- a/src/training/db_operations.py
+++ b/src/training/db_operations.py
@@ -7,6 +7,27 @@ from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
+# JSONB columns on athlete_profiles. The asyncpg pool registers no JSON codec,
+# so these come back as raw ``str`` and must be decoded before the API schemas
+# (which expect dicts) validate them.
+_PROFILE_JSONB_FIELDS = ("day_preferences", "available_slots")
+
+
+def _decode_profile_jsonb(profile: dict[str, Any]) -> dict[str, Any]:
+    """Decode JSONB profile columns asyncpg returns as strings into dicts.
+
+    Args:
+        profile: Raw profile dict from a fetched row.
+
+    Returns:
+        The same dict, with JSONB string fields parsed in place.
+    """
+    for field in _PROFILE_JSONB_FIELDS:
+        value = profile.get(field)
+        if isinstance(value, str):
+            profile[field] = json.loads(value)
+    return profile
+
 
 # ============================================
 # Athlete Profile Operations
@@ -26,7 +47,7 @@ async def get_athlete_profile(pool, user_id: int) -> Optional[dict[str, Any]]:
     row = await pool.fetchrow(
         "SELECT * FROM athlete_profiles WHERE user_id = $1", user_id
     )
-    return dict(row) if row else None
+    return _decode_profile_jsonb(dict(row)) if row else None
 
 
 async def upsert_athlete_profile(
@@ -83,7 +104,7 @@ async def upsert_athlete_profile(
         RETURNING *
     """
     row = await pool.fetchrow(query, *values)
-    return dict(row)
+    return _decode_profile_jsonb(dict(row))
 
 
 # ============================================

--- a/tests/test_training/test_db_operations.py
+++ b/tests/test_training/test_db_operations.py
@@ -126,6 +126,26 @@ async def test_upsert_athlete_profile_serializes_day_preferences():
 
 
 @pytest.mark.asyncio
+async def test_get_athlete_profile_decodes_jsonb_string_to_dict():
+    # asyncpg returns JSONB columns as raw strings (no codec on the pool);
+    # the profile must come back with day_preferences parsed to a dict.
+    row = {"user_id": 1, "day_preferences": '{"long_run": 6, "quality": [2]}'}
+    pool = make_pool(fetchrow=row)
+    result = await get_athlete_profile(pool, user_id=1)
+    assert result["day_preferences"] == {"long_run": 6, "quality": [2]}
+
+
+@pytest.mark.asyncio
+async def test_upsert_athlete_profile_decodes_jsonb_on_return():
+    # The RETURNING * row also carries JSONB as a string → decode before returning.
+    row = {"user_id": 1, "day_preferences": '{"long_run": 6}'}
+    pool = make_pool(fetchrow=row)
+    data = {"day_preferences": {"long_run": 6}}
+    result = await upsert_athlete_profile(pool, user_id=1, data=data)
+    assert result["day_preferences"] == {"long_run": 6}
+
+
+@pytest.mark.asyncio
 async def test_upsert_athlete_profile_ignores_unknown_fields():
     row = {"user_id": 1, "height_cm": 180}
     pool = make_pool(fetchrow=row)


### PR DESCRIPTION
## Symptôme
`Failed to update profile` dans le wizard (étape Profile) → `PUT /training-plans/profile` renvoyait 500.

## Cause
Le pool asyncpg n'enregistre aucun codec JSON → les colonnes JSONB reviennent en **str brute**. `AthleteProfileResponse` attend `Optional[dict]` et rejette la string (pydantic `dict_type`). Latent depuis toujours, déclenché seulement maintenant que `day_preferences` est rempli (seed de ce matin).

```
ValidationError: 1 validation error for AthleteProfileResponse
day_preferences
  Input should be a valid dictionary [type=dict_type, input_value='{"quality": [5], ...}', input_type=str]
```

## Correctif
Décodage des colonnes JSONB du profil (`day_preferences`, `available_slots`) à la lecture dans `get_athlete_profile` + `upsert_athlete_profile`. Correctif **localisé**, cohérent avec la convention du code (sérialisation manuelle, 12 sites `json.dumps`) — un codec asyncpg global imposerait de tous les retirer (refacto risquée).

Corrige aussi un bug latent : `_resolve_day_preferences` filtrait sur `isinstance(prefs, dict)`, donc les préférences de jours stockées en profil étaient **silencieusement ignorées** à la génération quand la valeur revenait en string.

## Validation
2 tests read-path ajoutés · 58 tests training verts · ruff check + format OK.